### PR TITLE
Fix loading xib from pod

### DIFF
--- a/Pod/Classes/Internal/AudioSystem.m
+++ b/Pod/Classes/Internal/AudioSystem.m
@@ -145,10 +145,11 @@ __strong static AudioSystem *singleton = nil; // this will be the one and only o
 - (void)playBundleFile:(NSString *)strFileAudio withDelegate:(id<AudioSystemDelegate>)delegate andUserData:(id)userData
 {
     // Construct URL to sound file
-    NSBundle *bundle = [NSBundle bundleForClass:STM.class];
-//    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle]
-//                              pathForResource:@"STM"
-//                              ofType:@"bundle"]];
+//    NSBundle *bundle = [NSBundle bundleForClass:STM.class];
+    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle]
+                                                 pathForResource:@"STM"
+                                                 ofType:@"bundle"]];
+    
     NSString *path = [NSString stringWithFormat:@"%@/%@", [bundle resourcePath], strFileAudio];
     NSURL *soundUrl = [NSURL fileURLWithPath:path];
     

--- a/Pod/Classes/Internal/VoiceCmdView.m
+++ b/Pod/Classes/Internal/VoiceCmdView.m
@@ -102,7 +102,11 @@ typedef enum eVoiceCmdAfterSound
 {
     VoiceCmdView *vcv;
     
-    NSBundle *bundle = [NSBundle bundleForClass:STM.class];
+    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle]
+                                                 pathForResource:@"STM"
+                                                 ofType:@"bundle"]];
+    
+//    NSBundle *bundle = [NSBundle bundleForClass:STM.class];
 
     vcv = [[bundle loadNibNamed:@"VoiceCmdView" owner:nil options:nil] objectAtIndex:0];
     CGRect frame = vcv.frame;


### PR DESCRIPTION
Loading a resource like a xib file from a cocoapod from within the cocoapod, the correct NSBundle path must be specified for the cocoapod resource.